### PR TITLE
fix: remove unnecessary class 'field-sizing-content' from Textarea co…

### DIFF
--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       {...props}


### PR DESCRIPTION

This pull request makes a minor adjustment to the `Textarea` component in `src/components/ui/textarea.tsx`. The change removed field-sizing-content class from Textarea element which caused it to explicitly expand with long strings of characters

- [`src/components/ui/textarea.tsx`](diffhunk://#diff-0c79b17a87407e4a1cc2f88e966e8c02b40b932e755c4e3cdd5052dadc109266L10-R10): Removed the `field-sizing-content` class from the `className` property of the `Textarea` component.