### PR TITLE
fix: update Content-Security-Policy to remove nonce from style-src and add openstreetmap.org to frame-src

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,11 +5,11 @@ export function middleware(request: NextRequest) {
   const cspHeader = `
     default-src 'self';
     script-src 'self' 'nonce-${nonce}' 'strict-dynamic' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://www.youtube.com https://s.ytimg.com;
-    style-src 'self' 'nonce-${nonce}' 'unsafe-inline';
+    style-src 'self' 'unsafe-inline';
     img-src 'self' blob: data:;
     font-src 'self' data:;
     connect-src 'self' blob: https://challenges.cloudflare.com https://api.notion.com https://vitals.vercel-analytics.com;
-    frame-src https://www.youtube.com https://www.youtube-nocookie.com https://challenges.cloudflare.com;
+    frame-src https://www.youtube.com https://www.youtube-nocookie.com https://challenges.cloudflare.com https://www.openstreetmap.org;
     object-src 'none';
     base-uri 'self';
     form-action 'self';


### PR DESCRIPTION
This pull request makes a small adjustment to the Content Security Policy (CSP) in the `middleware.ts` file. The change removes the use of a nonce for styles and allows embedding content from OpenStreetMap.

- Security policy updates:
  * Removed the `'nonce-${nonce}'` directive from the `style-src` CSP, now allowing only `'self'` and `'unsafe-inline'` for styles.
  * Added `https://www.openstreetmap.org` to the `frame-src` CSP, enabling the embedding of OpenStreetMap frames.